### PR TITLE
Fix PT-2420PC support

### DIFF
--- a/include/ptouch.h
+++ b/include/ptouch.h
@@ -27,6 +27,8 @@ struct _pt_tape_info {
 
 #define FLAG_NONE		0
 #define FLAG_UNSUP_RASTER	1
+#define FLAG_FORCE_TIFF		2
+
 struct _pt_dev_info {
 	int vid;		/* USB vendor ID */
 	int pid;		/* USB product ID */

--- a/src/ptouch-print.c
+++ b/src/ptouch-print.c
@@ -319,7 +319,7 @@ int parse_args(int argc, char **argv)
 
 int main(int argc, char *argv[])
 {
-	int i, lines, tape_width;
+	int i, lines = 0, tape_width;
 	char *line[MAX_LINES];
 	gdImage *im=NULL;
 	ptouch_dev ptdev=NULL;
@@ -369,10 +369,6 @@ int main(int argc, char *argv[])
 			exit(0);
 		} else if (strcmp(&argv[i][1], "-image") == 0) {
 			im=image_load(argv[++i]);
-			if (im != NULL) {
-				print_img(ptdev, im);
-				gdImageDestroy(im);
-			}
 		} else if (strcmp(&argv[i][1], "-text") == 0) {
 			for (lines=0; (lines < MAX_LINES) && (i < argc); lines++) {
 				if ((i+1 >= argc) || (argv[i+1][0] == '-')) {
@@ -381,26 +377,30 @@ int main(int argc, char *argv[])
 				i++;
 				line[lines]=argv[i];
 			}
-			if ((im=render_text(font_file, line, lines, tape_width)) == NULL) {
-				printf(_("could not render text\n"));
-				return 1;
-			}
-			if (save_png != NULL) {
-				write_png(im, save_png);
-			} else {
-				print_img(ptdev, im);
-			}
-			gdImageDestroy(im);
 		} else if (strcmp(&argv[i][1], "-cutmark") == 0) {
 			ptouch_cutmark(ptdev);
 		} else {
 			usage(argv[0]);
 		}
 	}
-	if (!save_png && ptouch_eject(ptdev) != 0) {
-		printf(_("ptouch_eject() failed\n"));
-		return -1;
+
+	if (lines) {
+		if ((im=render_text(font_file, line, lines, tape_width)) == NULL) {
+			printf(_("could not render text\n"));
+			return 1;
+		}
 	}
+		
+	if (save_png) {
+		write_png(im, save_png);
+	} else {
+		print_img(ptdev, im);
+		if (ptouch_eject(ptdev) != 0) {
+			printf(_("ptouch_eject() failed\n"));
+			return -1;
+		}
+	}
+	gdImageDestroy(im);
 	ptouch_close(ptdev);
 	libusb_exit(NULL);
 	return 0;

--- a/src/ptouch-print.c
+++ b/src/ptouch-print.c
@@ -397,7 +397,7 @@ int main(int argc, char *argv[])
 			usage(argv[0]);
 		}
 	}
-	if (ptouch_eject(ptdev) != 0) {
+	if (!save_png && ptouch_eject(ptdev) != 0) {
 		printf(_("ptouch_eject() failed\n"));
 		return -1;
 	}


### PR DESCRIPTION
Hi!
PT-2420PC didn't work with the current code. It seems that the pixel data must be TIFF/RLE encoded with the 2420, so I added a FORCE_TIFF flag to fix that. Also, I've added some other minor improvements.

Btw, this might also work for other models, but I only have access to a 2420.